### PR TITLE
Add contracts to simple inline functions with lambda parameter where possible

### DIFF
--- a/ui-engine/build.gradle.kts
+++ b/ui-engine/build.gradle.kts
@@ -16,7 +16,10 @@ tasks.compileJava.get().run {
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
 }
-tasks.compileKotlin.get().kotlinOptions.jvmTarget = "1.8"
+tasks.compileKotlin.get().kotlinOptions.run {
+    jvmTarget = "1.8"
+    freeCompilerArgs += listOf("-opt-in=kotlin.contracts.ExperimentalContracts")
+}
 
 publishing {
     publications {

--- a/ui-engine/src/main/kotlin/ru/cristalix/uiengine/element/ContextGui.kt
+++ b/ui-engine/src/main/kotlin/ru/cristalix/uiengine/element/ContextGui.kt
@@ -9,8 +9,13 @@ import ru.cristalix.uiengine.ClickEvent
 import ru.cristalix.uiengine.UIEngine
 import ru.cristalix.uiengine.utility.MouseButton
 import ru.cristalix.uiengine.utility.V3
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 inline fun safe(action: () -> Unit) {
+    contract {
+        callsInPlace(action, InvocationKind.EXACTLY_ONCE)
+    }
     try {
         action()
     } catch (e: Exception) {

--- a/ui-engine/src/main/kotlin/ru/cristalix/uiengine/utility/Flex.kt
+++ b/ui-engine/src/main/kotlin/ru/cristalix/uiengine/utility/Flex.kt
@@ -2,9 +2,16 @@ package ru.cristalix.uiengine.utility
 
 import ru.cristalix.uiengine.element.Parent
 import ru.cristalix.uiengine.element.RectangleElement
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.math.abs
 
-inline fun flex(setup: Flex.() -> Unit) = Flex().also(setup)
+inline fun flex(setup: Flex.() -> Unit): Flex {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return Flex().also(setup)
+}
 
 enum class FlexDirection(
         val kx: Int,

--- a/ui-engine/src/main/kotlin/ru/cristalix/uiengine/utility/UI.kt
+++ b/ui-engine/src/main/kotlin/ru/cristalix/uiengine/utility/UI.kt
@@ -1,15 +1,47 @@
 package ru.cristalix.uiengine.utility
 
 import ru.cristalix.uiengine.element.*
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
-inline fun rectangle(setup: RectangleElement.() -> Unit) = RectangleElement().also(setup)
+inline fun rectangle(setup: RectangleElement.() -> Unit): RectangleElement {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return RectangleElement().also(setup)
+}
 
-inline fun text(setup: TextElement.() -> Unit) = TextElement().also(setup)
+inline fun text(setup: TextElement.() -> Unit): TextElement {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return TextElement().also(setup)
+}
 
-inline fun item(setup: ItemElement.() -> Unit) = ItemElement().also(setup)
+inline fun item(setup: ItemElement.() -> Unit): ItemElement {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return ItemElement().also(setup)
+}
 
-inline fun cube(setup: CuboidElement.() -> Unit) = CuboidElement().also(setup)
+inline fun cube(setup: CuboidElement.() -> Unit): CuboidElement {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return CuboidElement().also(setup)
+}
 
-inline fun sphere(setup: SphereElement.() -> Unit) = SphereElement().also(setup)
+inline fun sphere(setup: SphereElement.() -> Unit): SphereElement {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return SphereElement().also(setup)
+}
 
-inline fun carved(setup: CarvedRectangle.() -> Unit) = CarvedRectangle().also(setup)
+inline fun carved(setup: CarvedRectangle.() -> Unit): CarvedRectangle {
+    contract {
+        callsInPlace(setup, InvocationKind.EXACTLY_ONCE)
+    }
+    return CarvedRectangle().also(setup)
+}


### PR DESCRIPTION
Use-case is building complex UI while also storing some elements for future operations. Example:
```kotlin
val text: TextElement
+rectangle {
    +carved {

    }

    +rectangle {
        text = +text {

        }
    }
}
text.content = "123"

UIEngine.schedule(10) {
    text.content = "456"
}
```
Previously, we had to make `text` a lateinit variable which is not correct (`text` is actually always initialized)